### PR TITLE
Synchronize listeners array

### DIFF
--- a/src/main/java/net/jacobpeterson/alpaca/websocket/client/AlpacaWebsocketClient.java
+++ b/src/main/java/net/jacobpeterson/alpaca/websocket/client/AlpacaWebsocketClient.java
@@ -216,13 +216,11 @@ public class AlpacaWebsocketClient implements WebsocketClient {
         AlpacaStreamMessageType alpacaStreamMessageType = (AlpacaStreamMessageType) streamMessageType;
         AlpacaStreamMessage alpacaStreamMessage = (AlpacaStreamMessage) streamMessage;
 
-        synchronized (listeners) {
-            for (AlpacaStreamListener alpacaStreamListener : listeners) {
-                if (alpacaStreamListener.getStreamMessageTypes() == null ||
-                        alpacaStreamListener.getStreamMessageTypes().isEmpty() ||
-                        alpacaStreamListener.getStreamMessageTypes().contains(alpacaStreamMessageType)) {
-                    alpacaStreamListener.onStreamUpdate(alpacaStreamMessageType, alpacaStreamMessage);
-                }
+        for (AlpacaStreamListener alpacaStreamListener : new ArrayList<>(listeners)) {
+            if (alpacaStreamListener.getStreamMessageTypes() == null ||
+                    alpacaStreamListener.getStreamMessageTypes().isEmpty() ||
+                    alpacaStreamListener.getStreamMessageTypes().contains(alpacaStreamMessageType)) {
+                alpacaStreamListener.onStreamUpdate(alpacaStreamMessageType, alpacaStreamMessage);
             }
         }
     }
@@ -286,17 +284,16 @@ public class AlpacaWebsocketClient implements WebsocketClient {
     public Set<AlpacaStreamMessageType> getRegisteredMessageTypes() {
         Set<AlpacaStreamMessageType> registeredStreamMessageTypes = new HashSet<>();
 
-        synchronized (listeners) {
-            for (AlpacaStreamListener alpacaStreamListener : listeners) {
-                Set<AlpacaStreamMessageType> alpacaStreamMessageTypes = alpacaStreamListener.getStreamMessageTypes();
+        for (AlpacaStreamListener alpacaStreamListener : new ArrayList<>(listeners)) {
+            Set<AlpacaStreamMessageType> alpacaStreamMessageTypes = alpacaStreamListener.getStreamMessageTypes();
 
-                // if its empty, assume they want everything
-                Set<AlpacaStreamMessageType> streamMessageTypesToAdd = alpacaStreamMessageTypes == null ? new HashSet<>() :
-                        alpacaStreamMessageTypes.stream().filter(AlpacaStreamMessageType::isAPISubscribable)
-                                .collect(Collectors.toSet());
+            // if its empty, assume they want everything
+            Set<AlpacaStreamMessageType> streamMessageTypesToAdd =
+                    alpacaStreamMessageTypes == null ? new HashSet<>() :
+                            alpacaStreamMessageTypes.stream().filter(AlpacaStreamMessageType::isAPISubscribable)
+                                    .collect(Collectors.toSet());
 
-                registeredStreamMessageTypes.addAll(streamMessageTypesToAdd);
-            }
+            registeredStreamMessageTypes.addAll(streamMessageTypesToAdd);
         }
 
         return registeredStreamMessageTypes;

--- a/src/main/java/net/jacobpeterson/alpaca/websocket/client/AlpacaWebsocketClient.java
+++ b/src/main/java/net/jacobpeterson/alpaca/websocket/client/AlpacaWebsocketClient.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -73,7 +72,7 @@ public class AlpacaWebsocketClient implements WebsocketClient {
         this.secret = secret;
         this.baseAPIURL = baseAPIURL.replace("https", "wss") + "/stream";
 
-        this.listeners = Collections.synchronizedList(new ArrayList<>());
+        this.listeners = new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/net/jacobpeterson/polygon/websocket/client/PolygonWebsocketClient.java
+++ b/src/main/java/net/jacobpeterson/polygon/websocket/client/PolygonWebsocketClient.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -75,7 +74,7 @@ public class PolygonWebsocketClient implements WebsocketClient {
         this.keyId = keyId;
         this.websocketURL = websocketURL;
 
-        this.listeners = Collections.synchronizedList(new ArrayList<>());
+        this.listeners = new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/net/jacobpeterson/polygon/websocket/client/PolygonWebsocketClient.java
+++ b/src/main/java/net/jacobpeterson/polygon/websocket/client/PolygonWebsocketClient.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -74,7 +75,7 @@ public class PolygonWebsocketClient implements WebsocketClient {
         this.keyId = keyId;
         this.websocketURL = websocketURL;
 
-        this.listeners = new ArrayList<>();
+        this.listeners = Collections.synchronizedList(new ArrayList<>());
     }
 
     @Override
@@ -207,7 +208,7 @@ public class PolygonWebsocketClient implements WebsocketClient {
         PolygonStreamMessageType polygonStreamMessageType = (PolygonStreamMessageType) streamMessageType;
         PolygonStreamMessage polygonStreamMessage = (PolygonStreamMessage) streamMessage;
 
-        for (PolygonStreamListener streamListener : listeners) {
+        for (PolygonStreamListener streamListener : new ArrayList<>(listeners)) {
             boolean sendToStreamListener = false;
 
             if (streamListener.getStockChannels().containsKey(polygonStreamMessage.getSym())) {
@@ -353,7 +354,7 @@ public class PolygonWebsocketClient implements WebsocketClient {
     private Map<String, Set<PolygonStreamMessageType>> getRegisteredTickerChannels(PolygonStreamListener exclude) {
         HashMap<String, Set<PolygonStreamMessageType>> registeredTickerChannels = new HashMap<>();
 
-        for (PolygonStreamListener streamListener : listeners) {
+        for (PolygonStreamListener streamListener : new ArrayList<>(listeners)) {
             if (streamListener.equals(exclude)) {
                 continue;
             }


### PR DESCRIPTION
This makes the listeners array list interactions thread-safe. Currently, if a listener is added or removed while receiving a notification you will get a concurrent modification exception. This fixes that by simply wrapping the listeners in a synchronized list impl and synchronizing on the listeners array any time iteration is to be performed.

**Disclaimer: this is untested, I encountered the issue, and made this change in github ui instead of simply creating an issue**