### PR TITLE
Define ACTION_REQUIRED account status enum.

### DIFF
--- a/schema_json/endpoint/account/enums/account_status.json
+++ b/schema_json/endpoint/account/enums/account_status.json
@@ -9,7 +9,8 @@
     "APPROVAL_PENDING",
     "ACTIVE",
     "REJECTED",
-    "DISABLED"
+    "DISABLED",
+    "ACTION_REQUIRED"
   ],
   "javaEnums": [
     {
@@ -35,6 +36,9 @@
     },
     {
       "description": "The account has been disabled."
+    },
+    {
+      "description": "The account requires manual attention."
     }
   ]
 }


### PR DESCRIPTION
Not sure how to regenerate the java enums though.

Defined (vaguely) in the [BrokerAPI docs](https://alpaca.markets/docs/broker/api-references/accounts/accounts/#account-status)